### PR TITLE
[FIX] set a samesite to None for cookie

### DIFF
--- a/django_vote_16th/settings/base.py
+++ b/django_vote_16th/settings/base.py
@@ -149,3 +149,8 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SAMESITE = 'None'


### PR DESCRIPTION
AS-IS

- 기존의 크롬 보안정책 때문에 백엔드 서버에서 쿠키를 보낼 때 Samesite에 대한 설정에 대해서 별도로 해주지 않았다고 한다.
- 이 문제는 크롬에서 2020년 8월부터 Samesite에 대한 설정이 Lax로 기본 설정되어 발생되는 문제

TO-BE

- 그래서 setting.py 부분에 samesite가 기본으로 None으로 되도록 설정하는 것을 추가